### PR TITLE
Add support for REELS

### DIFF
--- a/src/Instagram/User/Media.php
+++ b/src/Instagram/User/Media.php
@@ -78,8 +78,8 @@ class Media extends User {
             'params' => $params ? $params : array()
         );
 
-        if ( isset( $params[Params::VIDEO_URL] ) ) { // video container requires more params
-            $postParams['params'][Params::MEDIA_TYPE] = MediaTypes::VIDEO;
+        if ( isset( $params[Params::VIDEO_URL] ) && !isset( $postParams['params'][Params::MEDIA_TYPE] ) ) { // video container requires more params and to not overide  in case REELS is passed
+            $postParams['params'][Params::MEDIA_TYPE] = MediaTypes::VIDEO;    
         } elseif ( isset( $params[Params::CHILDREN] ) ) { // carousel container requires more params
             $postParams['params'][Params::MEDIA_TYPE] = MediaTypes::CAROUSEL;
         }


### PR DESCRIPTION
In case REELS is set as the media_type, the current code has been overriding it.

In case media_type is  being passed, regardless if it's REELS or not, just skip it.